### PR TITLE
Add python dependencies(pyyaml,jsonrpcclient) for JSONRPC mock test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY solc /usr/bin/
 RUN chmod +x /usr/bin/solc
 
 RUN pip install -U pip
-RUN pip install ethereum==2.2.0 pysodium toml
+RUN pip install ethereum==2.2.0 PyYAML==3.12 jsonrpcclient==2.5.2 pysodium toml
 
 
 COPY libgmssl.so.1.0.0 /usr/local/lib/


### PR DESCRIPTION
## Q & A
### Why jsonrpcclient?
Because current bash CI script can not check the return data of JSONRPC call. `jsonrpcclient` is a handy library for doing JSONRPC call.

### Why yaml?
* We should write comments to mock data, to tell the reader how we construct the mock data. (so I don't choose json format)
* We should be able to write nested complex data structure easily. (so I don't choose toml format)
